### PR TITLE
Added some clarification to readme in case people are using storyboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Finally, you can use a YLTableView to connect everything together.
   tableView.delegate = dataSource;
   
   // Registering cells and reuse identifiers
+  // Warning - This is not necessary if you're registering the cell explicitly 
+  // through storyboard prototype cells.
   [tableView registerClass:[YLExampleTextCell class] forCellReuseIdentifier:NSStringFromClass([YLExampleTextCell class])];
   
   self.view = tableView;


### PR DESCRIPTION
Doesn't really make sense why this actually breaks the storyboard approach, seems like a last one in type of thing which shouldn't have an adverse effect on anything. In my case, removing the registerClass  made everything work fine. 

Seems like there are other documented occurrences to support this as well. 
http://stackoverflow.com/questions/23096664/iboutlets-are-nil-when-using-custom-tableviewcells-in-a-storyboard

Feel free to take it, change it, ignore it.
