### PR TITLE
Add +[YLTableViewCell estimatedRowHeightForModel:]

### DIFF
--- a/Classes/YLTableViewCell.h
+++ b/Classes/YLTableViewCell.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Defines required methods that a UITableViewCell subclass must implement to work with a YLTableViewDataSource
  */
@@ -23,4 +25,16 @@
  */
 + (CGFloat)estimatedRowHeight;
 
+@optional
+
+/**
+ Estimated height for a cell with the given model.
+
+ This method is optional, but if implemented it will be called instead of estimatedRowHeight within
+ tableView:estimatedHeightForRowAtIndexPath:
+ */
++ (CGFloat)estimatedRowHeightForModel:(id)model;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/YLTableViewDataSource.m
+++ b/Classes/YLTableViewDataSource.m
@@ -176,6 +176,12 @@
 
   Class cellClass = [(YLTableView *)tableView cellClassForReuseIdentifier:[self tableView:tableView reuseIdentifierForCellAtIndexPath:indexPath]];
   NSAssert([cellClass conformsToProtocol:@protocol(YLTableViewCell)], @"You can only use cells conforming to YLTableViewCell.");
+
+  if ([cellClass respondsToSelector:@selector(estimatedRowHeightForModel:)]) {
+    id model = [self tableView:tableView modelForCellAtIndexPath:indexPath];
+    return [cellClass estimatedRowHeightForModel:model];
+  }
+
   return [(id<YLTableViewCell>)cellClass estimatedRowHeight];
 }
 

--- a/YLTableViewTests/YLTableViewCellTestStub.h
+++ b/YLTableViewTests/YLTableViewCellTestStub.h
@@ -13,9 +13,16 @@
  */
 extern const CGFloat kYLTableViewCellStubHeight;
 
+
 /**
  YLTableViewCell stub used for testing purposes
  */
 @interface YLTableViewCellTestStub : UITableViewCell <YLTableViewCell>
+@end
 
+
+/**
+ YLTableViewCell stub that implements estimatedRowHeightForModel:.
+ */
+@interface YLTableViewCellTestStubCustomEstimatedHeight : UITableViewCell <YLTableViewCell>
 @end

--- a/YLTableViewTests/YLTableViewCellTestStub.m
+++ b/YLTableViewTests/YLTableViewCellTestStub.m
@@ -7,8 +7,10 @@
 //
 
 #import "YLTableViewCellTestStub.h"
+#import "YLTableViewDataSourceTestStub.h"
 
 const CGFloat kYLTableViewCellStubHeight = 100.0;
+
 
 @implementation YLTableViewCellTestStub
 
@@ -16,6 +18,21 @@ const CGFloat kYLTableViewCellStubHeight = 100.0;
 
 + (CGFloat)estimatedRowHeight {
   return kYLTableViewCellStubHeight;
+}
+
+@end
+
+
+@implementation YLTableViewCellTestStubCustomEstimatedHeight
+
+- (void)setModel:(id)model { }
+
++ (CGFloat)estimatedRowHeight {
+  return kYLTableViewCellStubHeight;
+}
+
++ (CGFloat)estimatedRowHeightForModel:(id)model {
+  return [(YLTableViewCellModelTestStub *)model estimatedHeight];
 }
 
 @end

--- a/YLTableViewTests/YLTableViewDataSourceTestStub.h
+++ b/YLTableViewTests/YLTableViewDataSourceTestStub.h
@@ -6,8 +6,31 @@
 //  Copyright © 2015 Yelp. All rights reserved.
 //
 
-#import "YLTableViewCell.h"
 #import "YLTableViewDataSource.h"
+
+
+/**
+ A cell model used by YLTableViewDataSourceTestStub.
+ */
+@interface YLTableViewCellModelTestStub : NSObject
+
+/**
+ The reuse identifier the datasource will return for this model.
+ */
+@property (copy, nonatomic) NSString *reuseIdentifier;
+
+/**
+ An estimated height that may be used by the cell in estimatedRowHeightForModel:.
+ */
+@property (assign, nonatomic) CGFloat estimatedHeight;
+
+/**
+ Create a model with the given reuse identifier and estimated height.
+ */
++ (instancetype)modelWithReuseIdentifier:(NSString *)reuseIdentifier estimatedHeight:(CGFloat)estimatedHeight;
+
+@end
+
 
 /**
  YLTableViewDataSource stub used for testing purposes
@@ -17,6 +40,6 @@
 /**
  This is used to populate the table with cells at their respective index paths
  */
-@property (copy, nonatomic) NSDictionary<NSIndexPath *, NSString *> *reuseIdentifiers;
+@property (copy, nonatomic) NSDictionary<NSIndexPath *, YLTableViewCellModelTestStub *> *models;
 
 @end

--- a/YLTableViewTests/YLTableViewDataSourceTestStub.m
+++ b/YLTableViewTests/YLTableViewDataSourceTestStub.m
@@ -7,13 +7,31 @@
 //
 
 #import "YLTableViewDataSourceTestStub.h"
+#import "YLTableViewDataSourceSubclass.h"
 
 const CGFloat kYLTableViewDataSourceTestStubOverriddenHeight = 200.0;
 
+
+@implementation YLTableViewCellModelTestStub
+
++ (instancetype)modelWithReuseIdentifier:(NSString *)reuseIdentifier estimatedHeight:(CGFloat)estimatedHeight {
+  YLTableViewCellModelTestStub *model = [[self alloc] init];
+  model.reuseIdentifier = reuseIdentifier;
+  model.estimatedHeight = estimatedHeight;
+  return model;
+}
+
+@end
+
+
 @implementation YLTableViewDataSourceTestStub
 
+- (id)tableView:(UITableView *)tableView modelForCellAtIndexPath:(NSIndexPath *)indexPath {
+  return self.models[indexPath];
+}
+
 - (NSString *)tableView:(UITableView *)tableView reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath {
-  return self.reuseIdentifiers[indexPath];
+  return self.models[indexPath].reuseIdentifier;
 }
 
 @end

--- a/YLTableViewTests/YLTableViewDataSourceTests.m
+++ b/YLTableViewTests/YLTableViewDataSourceTests.m
@@ -14,8 +14,6 @@
 
 #import <XCTest/XCTestCase.h>
 
-static NSString *const kCustomReuseIdentifier = @"NotAClass-ReuseId";
-
 @interface YLTableViewDataSourceTests : XCTestCase
 
 @property (strong, nonatomic) YLTableView *tableView;
@@ -31,13 +29,11 @@ static NSString *const kCustomReuseIdentifier = @"NotAClass-ReuseId";
   [super setUp];
   
   _tableView = [[YLTableView alloc] init];
-  [_tableView registerClass:[YLTableViewCellTestStub class]
-     forCellReuseIdentifier:NSStringFromClass([YLTableViewCellTestStub class])];
-  [_tableView registerClass:[YLTableViewCellTestStub class]
-     forCellReuseIdentifier:kCustomReuseIdentifier];
+  [_tableView registerClass:[YLTableViewCellTestStub class] forCellReuseIdentifier:@"StaticHeight"];
+  [_tableView registerClass:[YLTableViewCellTestStubCustomEstimatedHeight class] forCellReuseIdentifier:@"CustomHeight"];
 
   _dataSource = [[YLTableViewDataSourceTestStub alloc] init];
-  _dataSource.reuseIdentifiers = [self _reuseIdentifiersForTableView];
+  _dataSource.models = [self _modelsForTableView];
 
   _tableView.dataSource = _dataSource;
   _tableView.delegate = _dataSource;
@@ -45,31 +41,31 @@ static NSString *const kCustomReuseIdentifier = @"NotAClass-ReuseId";
 
 #pragma mark - Helpers
 
-- (NSDictionary<NSIndexPath *, NSString *> *)_reuseIdentifiersForTableView {
+- (NSDictionary<NSIndexPath *, YLTableViewCellModelTestStub *> *)_modelsForTableView {
   return @{
-    [self _indexPathForClassNameReuseIdentifier]: NSStringFromClass([YLTableViewCellTestStub class]),
-    [self _indexPathForCustomReuseIdentifier]: kCustomReuseIdentifier,
+    [self _indexPathForStaticHeightCell]: [YLTableViewCellModelTestStub modelWithReuseIdentifier:@"StaticHeight" estimatedHeight:0],
+    [self _indexPathForCustomHeightCell]: [YLTableViewCellModelTestStub modelWithReuseIdentifier:@"CustomHeight" estimatedHeight:50],
   };
 }
 
-- (NSIndexPath *)_indexPathForClassNameReuseIdentifier {
+- (NSIndexPath *)_indexPathForStaticHeightCell {
   return [NSIndexPath indexPathForRow:0 inSection:0];
 }
 
-- (NSIndexPath *)_indexPathForCustomReuseIdentifier {
+- (NSIndexPath *)_indexPathForCustomHeightCell {
   return [NSIndexPath indexPathForRow:1 inSection:0];
 }
 
 #pragma mark - Tests
 
-- (void)testEstimatedRowHeightForClassNameReuseIdentifier {
-  CGFloat height = [self.dataSource tableView:self.tableView estimatedHeightForRowAtIndexPath:[self _indexPathForClassNameReuseIdentifier]];
+- (void)testStaticEstimatedRowHeight {
+  CGFloat height = [self.dataSource tableView:self.tableView estimatedHeightForRowAtIndexPath:[self _indexPathForStaticHeightCell]];
   XCTAssertEqual(height, kYLTableViewCellStubHeight);
 }
 
-- (void)testEstimatedRowHeightForCustomReuseIdentifier {
-  CGFloat height = [self.dataSource tableView:self.tableView estimatedHeightForRowAtIndexPath:[self _indexPathForCustomReuseIdentifier]];
-  XCTAssertEqual(height, kYLTableViewCellStubHeight);
+- (void)testCustomEstimatedRowHeight {
+  CGFloat height = [self.dataSource tableView:self.tableView estimatedHeightForRowAtIndexPath:[self _indexPathForCustomHeightCell]];
+  XCTAssertEqual(height, 50);
 }
 
 - (void)testNonConformingCell {


### PR DESCRIPTION
Sometimes it's desirable to have access to the cell model when calculating a row height estimation; for example, some cells' height might vary wildly when displaying different content.

To accommodate this in a backwards-compatible fashion, we can add a `+[YLTableViewCell estimatedRowHeightForModel:]` method to the protocol that, if implemented, is passed the model and takes precedence over `+[YLTableVIewCell estimatedRowHeight]`.