### PR TITLE
No longer require that reuse identifiers be class names

### DIFF
--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -18,10 +18,10 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface YLTableView ()
 
-//! Maps reuse identifiers to header/footer view class strings
-@property (strong, nonatomic) NSMutableDictionary *headerFooterViewClassForReuseIdentifier;
+//! Maps reuse identifiers to header/footer view classes
+@property (strong, nonatomic) NSMutableDictionary<NSString *, Class> *headerFooterViewClassForReuseIdentifier;
 //! Maps reuse identifiers to sizing header/footer views
-@property (strong, nonatomic) NSMutableDictionary *sizingHeaderFooterViewsForReuseIdentifier;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, YLTableViewSectionHeaderFooterView *> *sizingHeaderFooterViewsForReuseIdentifier;
 
 @end
 NS_ASSUME_NONNULL_END
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_END
   [super registerClass:headerFooterViewClass forHeaderFooterViewReuseIdentifier:identifier];
 
   if (headerFooterViewClass) {
-    self.headerFooterViewClassForReuseIdentifier[identifier] = NSStringFromClass(headerFooterViewClass);
+    self.headerFooterViewClassForReuseIdentifier[identifier] = headerFooterViewClass;
   } else {
     [self.headerFooterViewClassForReuseIdentifier removeObjectForKey:identifier];
   }
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_END
   NSAssert(self.headerFooterViewClassForReuseIdentifier[reuseIdentifier], @"You must register a class for this reuse identifier.");
 
   if (!self.sizingHeaderFooterViewsForReuseIdentifier[reuseIdentifier]) {
-    Class headerFooterViewClass = NSClassFromString(self.headerFooterViewClassForReuseIdentifier[reuseIdentifier]);
+    Class headerFooterViewClass = self.headerFooterViewClassForReuseIdentifier[reuseIdentifier];
     YLTableViewSectionHeaderFooterView *const sizingHeaderFooterView = [(YLTableViewSectionHeaderFooterView *)[headerFooterViewClass alloc] initWithReuseIdentifier:reuseIdentifier];
     self.sizingHeaderFooterViewsForReuseIdentifier[reuseIdentifier] = sizingHeaderFooterView;
   }

--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -18,9 +18,6 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface YLTableView ()
 
-//! Maps reuse identifiers to sizing cells
-@property (strong, nonatomic) NSMutableDictionary *sizingCellForReuseIdentifier;
-
 //! Maps reuse identifiers to header/footer view class strings
 @property (strong, nonatomic) NSMutableDictionary *headerFooterViewClassForReuseIdentifier;
 //! Maps reuse identifiers to sizing header/footer views
@@ -33,8 +30,6 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style {
   if ((self = [super initWithFrame:frame style:style])) {
-    _sizingCellForReuseIdentifier = [NSMutableDictionary dictionary];
-
     _headerFooterViewClassForReuseIdentifier = [NSMutableDictionary dictionary];
     _sizingHeaderFooterViewsForReuseIdentifier = [NSMutableDictionary dictionary];
   }

--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -18,6 +18,9 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface YLTableView ()
 
+//! Maps reuse identifiers to cell classes
+@property (strong, nonatomic) NSMutableDictionary<NSString *, Class> *cellClassForReuseIdentifier;
+
 //! Maps reuse identifiers to header/footer view classes
 @property (strong, nonatomic) NSMutableDictionary<NSString *, Class> *headerFooterViewClassForReuseIdentifier;
 //! Maps reuse identifiers to sizing header/footer views
@@ -30,6 +33,8 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style {
   if ((self = [super initWithFrame:frame style:style])) {
+    _cellClassForReuseIdentifier = [NSMutableDictionary dictionary];
+
     _headerFooterViewClassForReuseIdentifier = [NSMutableDictionary dictionary];
     _sizingHeaderFooterViewsForReuseIdentifier = [NSMutableDictionary dictionary];
   }
@@ -41,7 +46,14 @@ NS_ASSUME_NONNULL_END
 - (void)registerClass:(Class)cellClass forCellReuseIdentifier:(NSString *)identifier {
   NSAssert(identifier, @"Must have a reuse identifier.");
   NSAssert([cellClass conformsToProtocol:@protocol(YLTableViewCell)], @"You can only use cells conforming to YLTableViewCell.");
+
   [super registerClass:cellClass forCellReuseIdentifier:identifier];
+
+  if (cellClass) {
+    self.cellClassForReuseIdentifier[identifier] = cellClass;
+  } else {
+    [self.cellClassForReuseIdentifier removeObjectForKey:identifier];
+  }
 }
 
 - (void)registerClass:(Class)headerFooterViewClass forHeaderFooterViewReuseIdentifier:(NSString *)identifier {
@@ -58,7 +70,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (Class)cellClassForReuseIdentifier:(NSString *)reuseIdentifier {
-  return NSClassFromString(reuseIdentifier);
+  return self.cellClassForReuseIdentifier[reuseIdentifier];
 }
 
 - (YLTableViewSectionHeaderFooterView *)sizingHeaderFooterViewForReuseIdentifier:(NSString *)reuseIdentifier {

--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -57,6 +57,10 @@ NS_ASSUME_NONNULL_END
   }
 }
 
+- (Class)cellClassForReuseIdentifier:(NSString *)reuseIdentifier {
+  return NSClassFromString(reuseIdentifier);
+}
+
 - (YLTableViewSectionHeaderFooterView *)sizingHeaderFooterViewForReuseIdentifier:(NSString *)reuseIdentifier {
   NSAssert(reuseIdentifier, @"Must have a reuse identifier.");
   NSAssert(self.headerFooterViewClassForReuseIdentifier[reuseIdentifier], @"You must register a class for this reuse identifier.");

--- a/Classes/YLTableViewDataSource.m
+++ b/Classes/YLTableViewDataSource.m
@@ -174,7 +174,7 @@
       return [self.indexPathToEstimatedRowHeight[[[self class] _keyForIndexPath:indexPath]] floatValue];
   }
 
-  Class cellClass = NSClassFromString([self tableView:tableView reuseIdentifierForCellAtIndexPath:indexPath]);
+  Class cellClass = [(YLTableView *)tableView cellClassForReuseIdentifier:[self tableView:tableView reuseIdentifierForCellAtIndexPath:indexPath]];
   NSAssert([cellClass conformsToProtocol:@protocol(YLTableViewCell)], @"You can only use cells conforming to YLTableViewCell.");
   return [(id<YLTableViewCell>)cellClass estimatedRowHeight];
 }

--- a/Classes/YLTableViewPrivate.h
+++ b/Classes/YLTableViewPrivate.h
@@ -14,6 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface YLTableView ()
 
 /**
+ Returns the cell class registered for this reuse identifier, or Nil if none was registered.
+ */
+- (nullable Class)cellClassForReuseIdentifier:(NSString *)reuseIdentifier;
+
+/**
  Returns a cached section header/footer view for this reuse identifier. The view should only be used for sizing purposes, not for display.
  */
 - (YLTableViewSectionHeaderFooterView *)sizingHeaderFooterViewForReuseIdentifier:(NSString *)reuseIdentifier;

--- a/YLTableViewTests/YLTableViewDataSourceTestStub.h
+++ b/YLTableViewTests/YLTableViewDataSourceTestStub.h
@@ -17,6 +17,6 @@
 /**
  This is used to populate the table with cells at their respective index paths
  */
-@property (copy, nonatomic) NSDictionary<NSIndexPath *, UITableViewCell<YLTableViewCell>* > *tableViewCells;
+@property (copy, nonatomic) NSDictionary<NSIndexPath *, NSString *> *reuseIdentifiers;
 
 @end

--- a/YLTableViewTests/YLTableViewDataSourceTestStub.m
+++ b/YLTableViewTests/YLTableViewDataSourceTestStub.m
@@ -13,7 +13,7 @@ const CGFloat kYLTableViewDataSourceTestStubOverriddenHeight = 200.0;
 @implementation YLTableViewDataSourceTestStub
 
 - (NSString *)tableView:(UITableView *)tableView reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath {
-  return NSStringFromClass([self.tableViewCells[indexPath] class]);
+  return self.reuseIdentifiers[indexPath];
 }
 
 @end


### PR DESCRIPTION
I found that there are only a couple places where we rely on reuse identifier == class name (in one case we convert back and forth needlessly), so I did some refactor to allow reuse identifiers that are not class names. This will make usage from Swift a bit nicer, since you don't need to `@objc` your classes.

I did identify a potential impact of this, though: previously, a class could be used for estimating height *without ever being registered*. So, for example, if I had a YLTableViewCell class `A`, I could use "A" as a reuse identifier without ever registering it and cells for those identifiers would use the estimated height from the `A` class, even is reuse identifier "A" was actually registered to another class. I consider this a bug, although our own tests were even using it! (We were asking for the estimated height of a cell with reuse id "YLTableViewCellTestStub" despite never registering that reuse id with the table.)