### PR TITLE
Allow YLTableViewCell conforming classes to be unregistered

### DIFF
--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -45,11 +45,12 @@ NS_ASSUME_NONNULL_END
 
 - (void)registerClass:(Class)cellClass forCellReuseIdentifier:(NSString *)identifier {
   NSAssert(identifier, @"Must have a reuse identifier.");
-  NSAssert([cellClass conformsToProtocol:@protocol(YLTableViewCell)], @"You can only use cells conforming to YLTableViewCell.");
 
   [super registerClass:cellClass forCellReuseIdentifier:identifier];
 
   if (cellClass) {
+    NSAssert([cellClass conformsToProtocol:@protocol(YLTableViewCell)], @"You can only use cells conforming to YLTableViewCell.");
+      
     self.cellClassForReuseIdentifier[identifier] = cellClass;
   } else {
     [self.cellClassForReuseIdentifier removeObjectForKey:identifier];

--- a/YLTableViewTests/YLTableViewDataSourceTests.m
+++ b/YLTableViewTests/YLTableViewDataSourceTests.m
@@ -76,6 +76,16 @@ static NSString *const kCustomReuseIdentifier = @"NotAClass-ReuseId";
   XCTAssertThrows([self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"UITableViewCell"]);
 }
 
+- (void)testUnregistereredTableCell {
+  NSString *const kUnregisteredReuseIdentifier = @"UnregisteredClass-ReuseId";
+    
+  [self.tableView registerClass:[YLTableViewCellTestStub class] forCellReuseIdentifier:kUnregisteredReuseIdentifier];
+  XCTAssertNotNil([self.tableView dequeueReusableCellWithIdentifier:kUnregisteredReuseIdentifier]);
+    
+  [self.tableView registerClass:nil forCellReuseIdentifier:kUnregisteredReuseIdentifier];
+  XCTAssertNil([self.tableView dequeueReusableCellWithIdentifier:kUnregisteredReuseIdentifier]);
+}
+
 - (void)testEstimatedRowHeightOverride {
   self.dataSource.shouldOverrideEstimatedRowHeight = YES;
   CGFloat height = [self.dataSource tableView:self.tableView estimatedHeightForRowAtIndexPath:[self _indexPathForCustomReuseIdentifier]];


### PR DESCRIPTION
Possible solution to https://github.com/Yelp/YLTableView/issues/24