### PR TITLE
Maintain the same YLTableView behavior on iOS11

### DIFF
--- a/Classes/YLTableView.m
+++ b/Classes/YLTableView.m
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_END
 
     _headerFooterViewClassForReuseIdentifier = [NSMutableDictionary dictionary];
     _sizingHeaderFooterViewsForReuseIdentifier = [NSMutableDictionary dictionary];
+
+    self.estimatedSectionHeaderHeight = 0;
+    self.estimatedSectionFooterHeight = 0;
   }
   return self;
 }

--- a/Classes/YLTableViewDataSource.m
+++ b/Classes/YLTableViewDataSource.m
@@ -150,7 +150,7 @@
     [self tableView:tableView configureHeader:headerView forSection:section];
     return [headerView heightForWidth:CGRectGetWidth(tableView.bounds)];
   } else {
-    return UITableViewAutomaticDimension;
+    return 0;
   }
 }
 
@@ -164,7 +164,7 @@
     [self tableView:tableView configureFooter:footerView forSection:section];
     return [footerView heightForWidth:CGRectGetWidth(tableView.bounds)];
   } else {
-    return UITableViewAutomaticDimension;
+    return 0;
   }
 }
 

--- a/YLTableView.podspec
+++ b/YLTableView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'YLTableView'
-  s.version      = '2.1.0'
+  s.version      = '2.1.1'
   s.license      = {:type => 'Apache 2', :file => 'LICENSE.txt'}
   s.summary      = 'Yelp iOS table view framework'
   s.homepage     = 'https://github.com/Yelp/YLTableView'


### PR DESCRIPTION
iOS11 makes self-sizing the default for UITableView. This is awesome, but it's also the default for section headers and footers, which YLTableView still doesn't support self-sizing for. (We don't have a standardized way to provide estimates and instead currently use a sizing view.)

This introduced a couple problems. The first is that we return `UITableViewAutomaticDimension` as the height when there is no header/footer. In iOS<10 this was treated as a 0 height, but in iOS11 the table view guesses a non-zero height, leaving weird blank spaces.

The second issue is that the default estimated height for header/footers has changed. As described in the beta release notes:
> The default value of the `estimatedRowHeight`, `estimatedSectionHeaderHeight`, and `estimatedSectionFooterHeight` properties is now `UITableViewAutomaticDimension`, which means the table view selects an estimated height to use.

This is a problem for us because the table view seems to estimate non-zero heights even when we have no header/footer, and the mismatched estimate vs actual height results in jarring stutters while scrolling up through some tables.

Fortunately, disabling this estimation fixes the problem and is pretty straightforward. Again from the beta release notes:
> If you have existing table view code that behaves differently when you build your app with the iOS 11 SDK, and you don’t want to adopt self-sizing, you can restore the previous behavior by disabling estimated heights by setting a value of zero for each estimated height property.

I've tested these changes on iOS<11 and iOS11, and there's no change from the old behavior, so this change effectively maintains the status quo for YLTableView in iOS11.
