### PR TITLE
Return automatic size for section header/footer if there's a title

### DIFF
--- a/Classes/YLTableViewDataSource.m
+++ b/Classes/YLTableViewDataSource.m
@@ -149,6 +149,9 @@
     headerView.sizingView = YES;
     [self tableView:tableView configureHeader:headerView forSection:section];
     return [headerView heightForWidth:CGRectGetWidth(tableView.bounds)];
+  } else if ([self respondsToSelector:@selector(tableView:titleForHeaderInSection:)] &&
+             [self tableView:tableView titleForHeaderInSection:section]) {
+    return UITableViewAutomaticDimension;
   } else {
     return 0;
   }
@@ -163,6 +166,9 @@
     footerView.sizingView = YES;
     [self tableView:tableView configureFooter:footerView forSection:section];
     return [footerView heightForWidth:CGRectGetWidth(tableView.bounds)];
+  } else if ([self respondsToSelector:@selector(tableView:titleForFooterInSection:)] &&
+             [self tableView:tableView titleForFooterInSection:section]) {
+    return UITableViewAutomaticDimension;
   } else {
     return 0;
   }


### PR DESCRIPTION
In #30, we changed section header/footers to have height zero if there was no view registered. Unfortunately this means that header/footer titles no longer render correctly, because they are reserved 0 height. If there's a non-nil title, it should be fine to keep returning the automatic size.