### PR TITLE
Exposed private headers in the framework header

### DIFF
--- a/Classes/YLRefreshHeaderView/YLRefreshHeaderViewPrivate.h
+++ b/Classes/YLRefreshHeaderView/YLRefreshHeaderViewPrivate.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Yelp. All rights reserved.
 //
 
+// NOTE: This header is not actually private. See PR#41: https://github.com/Yelp/YLTableView/pull/41
+
 #import "YLRefreshHeaderView.h"
 #import "YLRefreshHeaderViewSubclass.h"
 

--- a/Classes/YLTableViewFramework.h
+++ b/Classes/YLTableViewFramework.h
@@ -16,6 +16,7 @@ FOUNDATION_EXPORT const unsigned char YLTableViewVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <YLTableView/PublicHeader.h>
 #import <YLTableView/YLRefreshHeaderView.h>
+#import <YLTableView/YLRefreshHeaderViewPrivate.h>
 #import <YLTableView/YLRefreshHeaderViewSubclass.h>
 #import <YLTableView/YLTableView.h>
 #import <YLTableView/YLTableViewCell.h>
@@ -23,6 +24,8 @@ FOUNDATION_EXPORT const unsigned char YLTableViewVersionString[];
 #import <YLTableView/YLTableViewDataSource.h>
 #import <YLTableView/YLTableViewDataSourceSubclass.h>
 #import <YLTableView/YLTableViewHeaderFooterView.h>
+#import <YLTableView/YLTableViewPrivate.h>
 #import <YLTableView/YLTableViewSectionHeaderFooterLabelView.h>
 #import <YLTableView/YLTableViewSectionHeaderFooterView.h>
+#import <YLTableView/YLTableViewSectionHeaderFooterViewPrivate.h>
 #import <YLTableView/YLTableViewSectionHeaderFooterViewSubclass.h>

--- a/Classes/YLTableViewPrivate.h
+++ b/Classes/YLTableViewPrivate.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Yelp. All rights reserved.
 //
 
+// NOTE: This header is not actually private. See PR#41: https://github.com/Yelp/YLTableView/pull/41
+
 #import "YLTableView.h"
 
 @class YLTableViewSectionHeaderFooterView;

--- a/Classes/YLTableViewSectionHeaderFooterView/YLTableViewSectionHeaderFooterViewPrivate.h
+++ b/Classes/YLTableViewSectionHeaderFooterView/YLTableViewSectionHeaderFooterViewPrivate.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Yelp. All rights reserved.
 //
 
+// NOTE: This header is not actually private. See PR#41: https://github.com/Yelp/YLTableView/pull/41
+
 #import "YLTableViewSectionHeaderFooterView.h"
 
 @interface YLTableViewSectionHeaderFooterView ()

--- a/YLTableView.xcodeproj/project.pbxproj
+++ b/YLTableView.xcodeproj/project.pbxproj
@@ -16,11 +16,11 @@
 		78B38729228DCBD30037A5C2 /* YLTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB517A1C18B40E00F8528A /* YLTableViewDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B3872A228DCBD70037A5C2 /* YLTableViewDataSourceSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB517C1C18B40E00F8528A /* YLTableViewDataSourceSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B3872B228DCBDC0037A5C2 /* YLTableViewHeaderFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB517D1C18B40E00F8528A /* YLTableViewHeaderFooterView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78B3872C228DCBE20037A5C2 /* YLTableViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB517F1C18B40E00F8528A /* YLTableViewPrivate.h */; };
-		78B3872D228DCBE90037A5C2 /* YLRefreshHeaderViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51721C18B40E00F8528A /* YLRefreshHeaderViewPrivate.h */; };
+		78B3872C228DCBE20037A5C2 /* YLTableViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB517F1C18B40E00F8528A /* YLTableViewPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78B3872D228DCBE90037A5C2 /* YLRefreshHeaderViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51721C18B40E00F8528A /* YLRefreshHeaderViewPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B3872E228DCBF20037A5C2 /* YLTableViewSectionHeaderFooterLabelView.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51811C18B40E00F8528A /* YLTableViewSectionHeaderFooterLabelView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B3872F228DCBF80037A5C2 /* YLTableViewSectionHeaderFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51831C18B40E00F8528A /* YLTableViewSectionHeaderFooterView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78B38730228DCBFC0037A5C2 /* YLTableViewSectionHeaderFooterViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51851C18B40E00F8528A /* YLTableViewSectionHeaderFooterViewPrivate.h */; };
+		78B38730228DCBFC0037A5C2 /* YLTableViewSectionHeaderFooterViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51851C18B40E00F8528A /* YLTableViewSectionHeaderFooterViewPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B38731228DCBFF0037A5C2 /* YLTableViewSectionHeaderFooterViewSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CB51861C18B40E00F8528A /* YLTableViewSectionHeaderFooterViewSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		78B38732228DCC3E0037A5C2 /* YLRefreshHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = A8CB51711C18B40E00F8528A /* YLRefreshHeaderView.m */; };
 		78B38733228DCC4D0037A5C2 /* YLTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = A8CB51751C18B40E00F8528A /* YLTableView.m */; };


### PR DESCRIPTION
As part of adding Carthage compatibility, this fancy `YLTableViewFramework.h` header was added to expose the public headers of the project. Previously, the podspec was in charge of this. Unfortunately, the podspec exposed /all/ headers, not just public ones (so something like `YLTableViewPrivate.h` was actually not private):

```
 s.public_header_files = 'Classes/**/*.h
```

This PR updates the `YLTableViewFramework.h` to expose these private headers to maintain compatibility with projects that rely on these private headers.